### PR TITLE
fix: labels are null when parser is v2 but data is v1

### DIFF
--- a/packages/nota-server/src/lib/parser/jsonv2.js
+++ b/packages/nota-server/src/lib/parser/jsonv2.js
@@ -37,7 +37,7 @@ const parser = {
   },
   parse: json => {
     const annotations = (json.annotations || []).map(
-      ({ boundaries, type, labels }) => ({
+      ({ boundaries, type, labels = {} }) => ({
         boundaries,
         labelsName: type,
         labels

--- a/packages/nota-server/src/routes/annotations.js
+++ b/packages/nota-server/src/routes/annotations.js
@@ -4,7 +4,7 @@ const annotationTemplate = function(annotation) {
   return {
     id: annotation.id,
     boundaries: annotation.boundaries,
-    labels: annotation.labels,
+    labels: annotation.labels ?? {},
     labelsName: annotation.labelsName,
     taskItemId: annotation.taskItemId,
     status: annotation.status


### PR DESCRIPTION
## Fix

- Labels are null when parser is v2 but data is v1, annotation error