### PR TITLE
feat: add timeline vis presets

### DIFF
--- a/packages/nota-client/src/components/annotation/VideoTimelineVisualizations.test.js
+++ b/packages/nota-client/src/components/annotation/VideoTimelineVisualizations.test.js
@@ -2,6 +2,7 @@ jest.mock("../../lib/binaryVis");
 import { ResizeObserver, ResizeObserverEntry } from "@juggle/resize-observer";
 import { act, render, screen } from "@testing-library/react";
 import React from "react";
+import { ALL_PRESET } from "../../constants";
 import VideoControlsProvider from "./videoControls";
 import VideoTimelineVisualizations from "./VideoTimelineVisualizations";
 
@@ -13,6 +14,7 @@ beforeEach(() => {
 describe("VideoTimeLineVisualizations", () => {
   test("render nothing without data", async () => {
     let tree;
+    const ALL = { id: ALL_PRESET, label: "All", vis: [] };
 
     act(() => {
       tree = render(
@@ -24,6 +26,9 @@ describe("VideoTimeLineVisualizations", () => {
             timelineVis={[]}
             min={0}
             max={1}
+            timelineVisPresets={[ALL]}
+            selectedPreset={ALL}
+            changeTimelineVisState={() => {}}
           />
         </VideoControlsProvider>
       );
@@ -34,6 +39,11 @@ describe("VideoTimeLineVisualizations", () => {
 
   test("render timeline correctly", async () => {
     let tree;
+    const ALL = {
+      id: ALL_PRESET,
+      label: "All",
+      vis: ["test_timeline", "test_timeline_2", "test_timeline_not_existent"]
+    };
 
     act(() => {
       tree = render(
@@ -58,6 +68,9 @@ describe("VideoTimeLineVisualizations", () => {
             ]}
             min={0}
             max={1}
+            timelineVisPresets={[ALL]}
+            selectedPreset={ALL}
+            changeTimelineVisState={() => {}}
           />
         </VideoControlsProvider>
       );
@@ -72,6 +85,7 @@ describe("VideoTimeLineVisualizations", () => {
 
   test("render message when no matching vis", async () => {
     let tree;
+    const ALL = { id: ALL_PRESET, label: "All", vis: ["LINE_C"] };
 
     act(() => {
       tree = render(
@@ -88,6 +102,9 @@ describe("VideoTimeLineVisualizations", () => {
             ]}
             min={0}
             max={1}
+            timelineVisPresets={[ALL]}
+            selectedPreset={ALL}
+            changeTimelineVisState={() => {}}
           />
         </VideoControlsProvider>
       );

--- a/packages/nota-client/src/components/annotation/VideoTimelineVisualizationsControls.js
+++ b/packages/nota-client/src/components/annotation/VideoTimelineVisualizationsControls.js
@@ -1,13 +1,29 @@
 import React from "react";
 import { DiscreteColorLegend } from "react-vis";
 
-function VideoTimelineVisualizationsControls({ items, onToggleItem }) {
+function VideoTimelineVisualizationsControls({
+  items,
+  onToggleItem,
+  selectedPresetId,
+  presets,
+  onChangePreset
+}) {
   const handleItemClick = function(item) {
     onToggleItem(item.id);
+  };
+  const handlePresetChange = function(evt) {
+    onChangePreset(evt.target.value);
   };
 
   return (
     <div className="vis-controls">
+      <select onChange={handlePresetChange} value={selectedPresetId}>
+        {presets.map(preset => (
+          <option key={preset.id} value={preset.id} disabled={preset.disabled}>
+            {preset.label}
+          </option>
+        ))}
+      </select>
       <DiscreteColorLegend items={items} onItemClick={handleItemClick} />
     </div>
   );

--- a/packages/nota-client/src/components/annotation/containers/VideoTimelineVisualizationsContainer.js
+++ b/packages/nota-client/src/components/annotation/containers/VideoTimelineVisualizationsContainer.js
@@ -1,24 +1,61 @@
 import { connect } from "react-redux";
+import { setOptions } from "../../../actions";
+import { ALL_PRESET, CUSTOM_PRESET } from "../../../constants";
 import { selector } from "../../../lib/selector";
 import VideoTimelineVisualizations from "../VideoTimelineVisualizations";
 
 const mapStateToProps = state => {
   const db = selector(state);
-  const { timelineVis = [] } = db.select("folderTemplateMediaOptions");
+  const { timelineVis = [], timelineVisPresets = [] } = db.select(
+    "folderTemplateMediaOptions"
+  );
   const min = Math.min(0, ...timelineVis.map(vis => vis.min ?? 0));
   const max = Math.max(1, ...timelineVis.map(vis => vis.max ?? 1));
+  const templateId = state.taskAssignment?.data?.task?.taskTemplate?.id;
+  const timelineVisState = state.options.timelineVisState[templateId];
+  const selectedPresetId = timelineVisState?.preset ?? ALL_PRESET;
+  const selectedVis = timelineVisState?.vis ?? [];
+  const showVisPresets = [...timelineVisPresets];
+
+  showVisPresets.unshift(
+    {
+      id: CUSTOM_PRESET,
+      label: "",
+      vis: selectedPresetId === CUSTOM_PRESET ? selectedVis : [],
+      disabled: true
+    },
+    { id: ALL_PRESET, label: "All", vis: timelineVis.map(vis => vis.id) }
+  );
+  // Default to ALL_PRESET if not found
+  const selectedPreset =
+    showVisPresets.find(preset => preset.id === selectedPresetId) ??
+    timelineVisPresets[1];
 
   return {
     min,
     max,
-    timelineVis: timelineVis,
+    timelineVis,
+    timelineVisPresets: showVisPresets,
+    selectedPreset,
     projectId: state.taskAssignment?.data?.project?.id,
     taskId: state.taskAssignment?.data?.task?.id,
+    templateId,
     taskItemId: state.selectedImageId
   };
 };
 
-const VideoTimelineVisualizationsContainer = connect(mapStateToProps)(
-  VideoTimelineVisualizations
-);
+const mapDispatchToProps = dispatch => {
+  return {
+    changeTimelineVisState: (templateId, preset, vis) => {
+      dispatch(
+        setOptions({ timelineVisState: { [templateId]: { preset, vis } } })
+      );
+    }
+  };
+};
+
+const VideoTimelineVisualizationsContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(VideoTimelineVisualizations);
 export default VideoTimelineVisualizationsContainer;

--- a/packages/nota-client/src/constants.js
+++ b/packages/nota-client/src/constants.js
@@ -27,6 +27,10 @@ export const OPTION_LABEL_SHOW_OFF = "label_show_off";
 export const OPTION_LABEL_SHOW_HOVER = "label_show_hover";
 export const OPTION_LABEL_SHOW_ALWAYS = "label_show_always";
 
+/** TimelineVis Presets */
+export const CUSTOM_PRESET = "@@@CUSTOM@@@";
+export const ALL_PRESET = "@@@ALL@@@";
+
 export const ACTION_SELECT_ANNOTATION = "select_annotation";
 export const ACTION_SELECT_ANNOTATION_USER = "select_annotation_user";
 export const ACTION_CREATE_ANNOTATION = "create_annotation";

--- a/packages/nota-client/src/reducers/options.js
+++ b/packages/nota-client/src/reducers/options.js
@@ -8,17 +8,31 @@ const defaultState = {
   minScale: 0.5,
   maxScale: 12,
   maxScaleClick: 8,
-  timelineZoom: 1
-};
-const savedState = {
-  ...defaultState,
-  ...(JSON.parse(window.localStorage.getItem(KEY)) || {})
+  timelineZoom: 1,
+  timelineVisState: {}
 };
 
-export default (state = savedState, action, root) => {
+export default (
+  state = {
+    ...defaultState,
+    ...(JSON.parse(window.localStorage.getItem(KEY)) || {})
+  },
+  action,
+  root
+) => {
   switch (action.type) {
     case SET_OPTIONS_ACTION:
-      const newState = { ...state, ...action.options };
+      const { timelineVisState = {}, ...options } = action.options;
+      const newTimelineVisState = {
+        ...state.timelineVisState,
+        ...timelineVisState
+      };
+      const newState = {
+        ...state,
+        ...options,
+        timelineVisState: newTimelineVisState
+      };
+
       window.localStorage.setItem(KEY, JSON.stringify(newState));
 
       return newState;


### PR DESCRIPTION
Add presets to timeline visualizations and save the current selection into browser memory (local storage) (90)